### PR TITLE
Does not pass params to form 2 components

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,6 +5,9 @@
         :extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}
                      org.clojure/clojurescript {:mvn/version "1.11.60"}
                      com.bhauman/figwheel-main {:mvn/version "0.2.18"}
+                     reagent/reagent {:mvn/version "1.2.0"}
+                     cljsjs/react {:mvn/version "17.0.2-0"}
+                     cljsjs/react-dom {:mvn/version "17.0.2-0"}
                      cider/piggieback {:mvn/version "0.5.3"}
                      cjohansen/gadget-inspector {:mvn/version "0.2020.09.10"}
                      no.cjohansen/portfolio #_{:mvn/version "2023.03.21"}

--- a/portfolio/sasha/components/button_scenes.cljs
+++ b/portfolio/sasha/components/button_scenes.cljs
@@ -1,16 +1,25 @@
 (ns sasha.components.button-scenes
-  (:require [portfolio.dumdom :refer-macros [defscene]]
+  (:require [portfolio.reagent :refer-macros [defscene]]
             [sasha.components.button :refer [Button]]))
 
-(defscene button
-  (Button {:text "Click it"
-           :href "#"}))
+(defn form-1-component [{:keys [text] :as m}]
+  [:button m text])
 
-(defscene disabled-button
-  (Button {:text "Click it"
-           :disabled? true}))
+(defn form-2-component [_]
+  (let [add-num #(str % (rand-int 100))]
+    (fn [{:keys [text] :as m}]
+      [:button m (add-num text)])))
 
-(defscene button-with-spinner
-  (Button {:text "Click it"
-           :disabled? true
-           :spinner? true}))
+(defscene form-2-button
+  :params {:text "Click it"
+           :href "#"}
+  form-2-component)
+
+(defscene form-1-disabled-button
+  :params {:text "Click it"
+           :disabled true}
+  form-1-component)
+
+(defscene form-1-button-with-text-added
+  :params {:text (str "Click it" (rand-int 100))}
+  form-1-component)


### PR DESCRIPTION
This 'PR' demonstrates an issue with Portfolio where it does not pass `:params` in a `defscene` call for reagent to its component if the component is a [form 2 component, that is, a function returning a function.](https://github.com/reagent-project/reagent/blob/master/doc/CreatingReagentComponents.md#form-2--a-function-returning-a-function)